### PR TITLE
Add the initrd to run-qemu-aarch64

### DIFF
--- a/run-qemu-aarch64
+++ b/run-qemu-aarch64
@@ -6,6 +6,7 @@ qemu-system-aarch64 \
     -cpu cortex-a53 \
     -serial stdio \
     -kernel ./boot/Image \
+    -initrd ./boot/initramfs-linux.img \
     -append "root=/dev/vda2 rootfstype=ext4 rw console=ttyAMA0" \
     -hda dist/novix-aarch64-latest.img \
     -net nic,macaddr=de:ad:be:f0:12:34 \


### PR DESCRIPTION
Gets us pass the first panic where the kernel tries to mount a root fs on an unknown block by explicitly passing in the initrd which was built by the kernel.

Eventually, the initramfs image can be migrated into a partition and loaded as the default.